### PR TITLE
Null provider for the widget accessibility fontsize

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,38 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Privacy Subsystem implementation for accessibility_fontsize.
+ *
+ * @package    accessibility_fontsize
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace accessibility_fontsize\privacy;
+
+defined('MOODLE_INTERNAL') || die();
+
+class provider implements \core_privacy\local\metadata\null_provider {
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason() : string {
+        return 'privacy:metadata';
+    }
+}

--- a/lang/en/accessibility_fontsize.php
+++ b/lang/en/accessibility_fontsize.php
@@ -23,3 +23,4 @@
  */
 
 $string['pluginname'] = 'Font Size';
+$string['privacy:metadata'] = 'The plugin does not store any personal data.';

--- a/lang/ja/accessibility_fontsize.php
+++ b/lang/ja/accessibility_fontsize.php
@@ -23,3 +23,4 @@
  */
 
 $string['pluginname'] = '文字の大きさ';
+$string['privacy:metadata'] = 'このプラグインは個人データを一切保存しません。';


### PR DESCRIPTION
Hi @ponlawat-w ,

The widgets are breaking the unit tests and I've decided to add  a "null provider" as a fix. 

```
 core_privacy\privacy\provider_test::test_all_providers_compliant with data set "accessibility_fontsize" ('accessibility_fontsize', 'accessibility_fontsize\privac...ovider')
Failed asserting that false is true.

```
Local tests were successful for this widget after this change.

The changes require to include language strings for all the languages included in the plugin, and I used a translator to generate the language string for Japanese. Could you please review it and make any necessary corrections? 

If you accept the pull request I can make requests for other widgets bundled with the plugin.

Regards,
Pramith